### PR TITLE
Added 60dB integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eleven_labsrt
 
-This project helps you generate audio files using .srt (subtitle) files and [ElevenLabs](https://www.elevenlabs.io).
+This project helps you generate audio files using .srt (subtitle) files and a text-to-speech provider. Two providers are supported and are fully interchangeable: [ElevenLabs](https://www.elevenlabs.io) (default) and [60db](https://60db.ai). Select one per run with the `-p`/`--provider` flag.
 
 The idea is that it will first generate (and cache) all strings in your subtitles and then mix in the results in an audio file, respecting times as much as possible, for example if two subtitles overlap it will append them next to each other, never stripping any parts of the audio.
 
@@ -31,17 +31,19 @@ First, install dependencies:
 pip install -r requirements.txt
 ```
 
-You will then need to obtain an ElevenLabs API key by registering for an account and paying for one of their plans (otherwise you are limited to a small number of characters).
+You will then need an API key for whichever provider you want to use.
 
-To get your API key just go into the user dropdown and select `Profile`.
+- **ElevenLabs:** register for an account (paying for a plan lifts the small free character limit). Open the user dropdown, select `Profile`, and your API key is in the modal dialog that pops up.
+- **60db:** obtain an API key from your [60db](https://60db.ai) account.
 
-There is a modal dialog that pops up and your API key is in there, just create a .env file like this:
+Create a `.env` file like this:
 
 ```env
 ELEVENLABS_API_KEY = xxxxxx
+SIXTYDB_API_KEY = yyyyyy
 ``````
 
-Where xxxxx is your API key.
+Where `xxxxx` is your ElevenLabs API key and `yyyyyy` is your 60db API key. You only need to set the key for the provider(s) you intend to use.
 
 ## Usage
 
@@ -51,7 +53,9 @@ This is a command line app which accepts the following arguments:
 
 This application accepts several command line arguments to customize its behavior. Here is a brief description of each:
 
-- `-l`, `--list-voices`: This flag, when specified, lists all available voices from your ElevenLabs account, excluding default voices not cloned by you. Note that specifying this action does not convert anything.
+- `-p`, `--provider`: The TTS provider to use for this run. One of `elevenlabs` (default) or `60db`. All other behavior (voices, caching, mixing) is identical regardless of provider. Caches are kept separate per provider under `cache/<provider>/<voice>/`.
+
+- `-l`, `--list-voices`: This flag, when specified, lists all available voices from the selected provider's account. Note that specifying this action does not convert anything.
 
 - `-i`, `--input-file`: This argument should be followed by the path to the input SRT file to be processed (-i 01.srt).
 
@@ -59,11 +63,38 @@ This application accepts several command line arguments to customize its behavio
 
 - `-d`, `--debug`: This flag, when specified, enables the debug or verbose mode.
 
-- `-v`, `--voice`: This argument should be followed by the name of the voice to use when converting subtitles. The voice must be a valid voice on the ElevenLabs user account whose API key is used. If no voice is specified, the app will bail out.
+- `-v`, `--voice`: This argument should be followed by the name (or voice ID) of the voice to use when converting subtitles. The voice must exist on the account of the selected provider (whose API key is used). If no voice is specified, the app will bail out.
 
 - `-q`, `--prefer-queue`: This flag, when specified, places overlapping subtitles sequentially. If neither this nor `--prefer-speedup` is specified, the app will use this by default.
 
 - [WIP]`-s`, `--prefer-speedup`: This flag, when specified, prefers speeding up audio to fit overlapping subtitles. If neither `--prefer-speedup` nor `--prefer-queue` is specified, queue is used.
+
+## Choosing a provider
+
+The app supports two interchangeable TTS providers, selected per run with `-p`/`--provider`. ElevenLabs is the default, so existing commands keep working unchanged.
+
+```bash
+# List the voices available on each provider
+python src/main.py -l                       # ElevenLabs (default)
+python src/main.py -p 60db -l               # 60db
+
+# Generate audio with ElevenLabs (default provider)
+python src/main.py -v "Rachel" -i 01.srt -o out.mp3
+
+# Generate the same thing with 60db
+python src/main.py -p 60db -v "VoiceName" -i 01.srt -o out.mp3
+```
+
+Everything other than the provider choice is identical: voice selection, the character-count cost prompt, caching, and the final mix. Caches are kept separate per provider under `cache/<provider>/<voice>/`, so the same voice name on different providers never collides.
+
+## Providers
+
+| Provider | Flag value | API key (.env) | Endpoints used |
+|----------|------------|----------------|----------------|
+| ElevenLabs (default) | `elevenlabs` | `ELEVENLABS_API_KEY` | `text_to_speech.convert` (SDK), `voices.get_all` |
+| 60db | `60db` | `SIXTYDB_API_KEY` | `POST /tts-synthesize`, `GET /myvoices` |
+
+The 60db integration uses the synchronous `tts-synthesize` endpoint (returns base64-encoded MP3) with sensible tuning defaults (speed `1`, stability `50`, similarity `75`, enhance `true`).
 
 ## Generating only a set of subtitles
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pydub
 elevenlabs
 srt
 python-decouple
+requests

--- a/src/audio_manager.py
+++ b/src/audio_manager.py
@@ -1,5 +1,4 @@
 from cli_parser import get_args
-from elevenlabs_service import ElevenLabsService
 import pydub
 
 class AudioManager:
@@ -7,12 +6,12 @@ class AudioManager:
     strings = None
     vocal_cache = None
     args = get_args()
-    elevenLabsService = None
+    tts_service = None
 
-    def __init__(self, subtitles, cache, elevenlabsService):
+    def __init__(self, subtitles, cache, tts_service):
         self.subtitles = subtitles;
         self.vocal_cache = cache
-        self.elevenLabsService = elevenlabsService
+        self.tts_service = tts_service
 
     def generate_audio_files(self):
         self.strings = self.subtitles.get_strings()
@@ -23,12 +22,12 @@ class AudioManager:
             if self.vocal_cache.get_vocal(string) is None:
                 try:
                     print(f"Generating vocal for text {string}...")
-                    self.elevenLabsService.generate_audio(string)
+                    self.tts_service.generate_audio(string)
                     counter += 1
                     print(f"Generated string {counter} of {len(self.strings)}")
 
                 except Exception as e:
-                    print(f"Error generating vocal with ElevenLabs for text {string}: {e}")
+                    print(f"Error generating vocal for text {string}: {e}")
                     print(e)
                     exit(1)
 

--- a/src/cli_parser.py
+++ b/src/cli_parser.py
@@ -4,7 +4,8 @@ def get_args():
     parser = argparse.ArgumentParser(description='Convert SRT subtitle entries to audio using ElevenLabs and sync them.')
 
     # Define possible arguments
-    parser.add_argument('-l', '--list-voices', help='List available voices from ElevenLabs. specifying this action does not convert anything', action='store_true')
+    parser.add_argument('-p', '--provider', help='TTS provider to use. Default is elevenlabs.', choices=['elevenlabs', '60db'], default='elevenlabs')
+    parser.add_argument('-l', '--list-voices', help='List available voices from the selected provider. specifying this action does not convert anything', action='store_true')
     parser.add_argument('-i', '--input-file', help='Input SRT file to be processed.', type=str)
     parser.add_argument('-d', '--debug', help='Debug/verbose mode.', action='store_true')
     parser.add_argument('-v', '--voice', help='Voice to use when converting subtitles. Must be a valid voice on the ElevenLabs user account whose API key is used', type=str)

--- a/src/elevenlabs_service.py
+++ b/src/elevenlabs_service.py
@@ -1,14 +1,12 @@
 import sys
 from elevenlabs.client import ElevenLabs
 from decouple import config
+from tts_service import TTSService
 
-class ElevenLabsService:
-    api_key = ""
-    voices = []  # list of voice metadata objects
-    voice_id = None
-
+class ElevenLabsService(TTSService):
     def __init__(self) -> None:
-        self.api_key = config("ELEVENLABS_API_KEY")
+        super().__init__()
+        self.api_key = config("ELEVENLABS_API_KEY", default="")
         if not self.api_key:
             print(
                 "Error: ELEVENLABS_API_KEY is missing in the .env file.",
@@ -17,12 +15,6 @@ class ElevenLabsService:
             sys.exit(1)
         self.elevenlabs = ElevenLabs(api_key=self.api_key)
 
-    def list_voices(self):
-        self.populate_voice_list()
-        print("Available voices:\n")
-        for v in self.voices:
-            print(f"- Name: {v.name} | ID: {v.voice_id} | Category: {getattr(v, 'category', 'unknown')} | Description: {v.description}")
-
     def populate_voice_list(self):
         resp = self.elevenlabs.voices.get_all()
         # The SDK might return a structure, adapt accordingly
@@ -30,20 +22,15 @@ class ElevenLabsService:
             voices_list = list(resp)[0][1]
         except Exception:
             voices_list = resp
-        # Filter or accept all categories, up to you
-        self.voices = voices_list
-
-    def set_voice(self, voice_identifier):
-        """
-        voice_identifier can be voice name or voice_id
-        """
-        self.populate_voice_list()
-        for v in self.voices:
-            if v.name == voice_identifier or v.voice_id == voice_identifier:
-                self.voice_id = v.voice_id
-                return
-        print(f"Invalid voice specified or not found in your ElevenLabs account. Tried: {voice_identifier}")
-        sys.exit(1)
+        self.voices = [
+            {
+                "name": v.name,
+                "voice_id": v.voice_id,
+                "category": getattr(v, "category", "unknown"),
+                "description": getattr(v, "description", None),
+            }
+            for v in voices_list
+        ]
 
     def generate_audio(self, text):
         if not self.voice_id:

--- a/src/main.py
+++ b/src/main.py
@@ -1,20 +1,26 @@
 from cli_parser import get_args
-from elevenlabs_service import ElevenLabsService
 from audio_manager import AudioManager
 from subtitle_helper import SubtitleHelper
 from vocal_cache import VocalCache
 
+def make_tts_service(provider):
+    if provider == "60db":
+        from sixtydb_service import SixtyDBService
+        return SixtyDBService()
+    from elevenlabs_service import ElevenLabsService
+    return ElevenLabsService()
+
 def main():
     # Parse command line arguments
     args = get_args()
-    elevenLabsService = ElevenLabsService()
+    ttsService = make_tts_service(args.provider)
 
     if args.list_voices:
-        elevenLabsService.list_voices()
+        ttsService.list_voices()
         exit(0)
-    
+
     if args.voice:
-        elevenLabsService.set_voice(args.voice)
+        ttsService.set_voice(args.voice)
 
     if not args.input_file:
         print("No input file specified, exiting...")
@@ -30,7 +36,7 @@ def main():
     if args.debug:
         print(f"Successfully retrieved {len(strings_to_generate)} strings.")
 
-    vocalCache = VocalCache(args.voice)
+    vocalCache = VocalCache(args.voice, args.provider)
     cached_strings = vocalCache.get_cached_strings()
 
     if args.debug:
@@ -49,7 +55,7 @@ def main():
             print("Aborting...")
             exit()
 
-    audioManager = AudioManager(subtitleHelper, vocalCache, elevenLabsService)
+    audioManager = AudioManager(subtitleHelper, vocalCache, ttsService)
     audioManager.generate_audio_files()
     audioManager.create_mix()
 

--- a/src/sixtydb_service.py
+++ b/src/sixtydb_service.py
@@ -1,0 +1,72 @@
+import sys
+import base64
+import requests
+from decouple import config
+from tts_service import TTSService
+
+class SixtyDBService(TTSService):
+    BASE_URL = "https://api.60db.ai"
+
+    # Hardcoded tuning defaults (match the 60db API defaults).
+    DEFAULT_SPEED = 1
+    DEFAULT_STABILITY = 50
+    DEFAULT_SIMILARITY = 75
+    DEFAULT_ENHANCE = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.api_key = config("SIXTYDB_API_KEY", default="")
+        if not self.api_key:
+            print(
+                "Error: SIXTYDB_API_KEY is missing in the .env file.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        })
+
+    def populate_voice_list(self):
+        resp = self.session.get(f"{self.BASE_URL}/myvoices")
+        resp.raise_for_status()
+        payload = resp.json()
+        # Response shape: {"success": ..., "message": ..., "data": [ ... ]}
+        data = payload.get("data", []) if isinstance(payload, dict) else payload
+        self.voices = [
+            {
+                "name": v.get("name"),
+                "voice_id": v.get("voice_id"),
+                "category": v.get("category", "unknown"),
+                "description": v.get("description"),
+            }
+            for v in data
+        ]
+
+    def generate_audio(self, text):
+        if not self.voice_id:
+            print("Error: No voice_id has been set.")
+            sys.exit(1)
+        body = {
+            "text": text,
+            "voice_id": self.voice_id,
+            "speed": self.DEFAULT_SPEED,
+            "stability": self.DEFAULT_STABILITY,
+            "similarity": self.DEFAULT_SIMILARITY,
+            "enhance": self.DEFAULT_ENHANCE,
+            "output_format": "mp3",
+        }
+        resp = self.session.post(f"{self.BASE_URL}/tts-synthesize", json=body)
+        resp.raise_for_status()
+        payload = resp.json()
+
+        if not payload.get("success", True):
+            raise RuntimeError(f"60db TTS failed: {payload.get('message')}")
+
+        audio_b64 = payload.get("audio_base64")
+        if not audio_b64:
+            raise RuntimeError("60db TTS returned no audio data.")
+
+        with open("temp.mp3", "wb") as f:
+            f.write(base64.b64decode(audio_b64))

--- a/src/tts_service.py
+++ b/src/tts_service.py
@@ -1,0 +1,47 @@
+import sys
+
+class TTSService:
+    """
+    Base interface shared by all text-to-speech providers.
+
+    Subclasses must implement populate_voice_list() (filling self.voices with
+    normalized voice dicts) and generate_audio(text) (writing the result to
+    temp.mp3). Everything downstream (AudioManager, VocalCache) only depends on
+    this interface, so providers are fully interchangeable.
+
+    Normalized voice dict shape:
+        {"name": str, "voice_id": str, "category": str, "description": str|None}
+    """
+
+    def __init__(self) -> None:
+        self.voices = []  # list of normalized voice dicts
+        self.voice_id = None
+
+    def populate_voice_list(self):
+        raise NotImplementedError
+
+    def generate_audio(self, text):
+        raise NotImplementedError
+
+    def list_voices(self):
+        self.populate_voice_list()
+        print("Available voices:\n")
+        for v in self.voices:
+            print(
+                f"- Name: {v['name']} | ID: {v['voice_id']} "
+                f"| Category: {v.get('category', 'unknown')} "
+                f"| Description: {v.get('description')}"
+            )
+
+    def set_voice(self, voice_identifier):
+        """voice_identifier can be a voice name or a voice_id."""
+        self.populate_voice_list()
+        for v in self.voices:
+            if v["name"] == voice_identifier or v["voice_id"] == voice_identifier:
+                self.voice_id = v["voice_id"]
+                return
+        print(
+            f"Invalid voice specified or not found in your account. "
+            f"Tried: {voice_identifier}"
+        )
+        sys.exit(1)

--- a/src/vocal_cache.py
+++ b/src/vocal_cache.py
@@ -7,11 +7,14 @@ class VocalCache:
     cache_directory = 'cache'
     voice = None
 
-    def __init__(self, voice_name):
+    def __init__(self, voice_name, provider="elevenlabs"):
         self.cache = {}
         self.voice = voice_name
-        self.cache_directory = os.path.join(self.cache_directory, voice_name)
-        self.cache_filename = f"{self.cache_filename}_{self.voice}.json"
+        self.provider = provider
+        # Namespace the cache by provider so identical voice names across
+        # providers never collide (cache/<provider>/<voice>/).
+        self.cache_directory = os.path.join(self.cache_directory, provider, voice_name)
+        self.cache_filename = f"{self.cache_filename}_{provider}_{self.voice}.json"
 
     def load_cache(self):
         if not os.path.exists(self.cache_filename):


### PR DESCRIPTION
 What we added  
  - 60db as a second TTS provider, fully interchangeable with ElevenLabs.
  - -p/--provider flag (elevenlabs default, or 60db).
  - New SixtyDBService (/tts-synthesize + /myvoices) and a shared TTSService base class both providers extend.
  - Per-provider cache (cache/<provider>/<voice>/) so voice names never collide.
  - New SIXTYDB_API_KEY env var, requests dependency, and updated README.

  How to use it

  1. pip install -r requirements.txt
  2. Add to .env: SIXTYDB_API_KEY = your-key
  3. Run with -p 60db:
  python src/main.py -p 60db -l                                  # list voices
  python src/main.py -p 60db -v "VoiceName" -i 01.srt -o out.mp3 # generate

  ElevenLabs stays the default, so old commands work unchanged.
